### PR TITLE
move tap to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "readmeFilename": "readme.md",
   "gitHead": "a219306e93712cb4380286b44360fea4406d49d3",
-  "dependencies": {
+  "devDependencies": {
     "tap": "~0.3.3"
   }
 }


### PR DESCRIPTION
The reason is that tap has a big tree that ends up in a huge directory that doesn't work on Windows and I think it should go on devDeps.

thanks
