### PR TITLE
meta: use buffer.from or buffer.alloc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_install:
   - npm install -g typescript@2
 
 node_js:
+  - "10"
+  - "8"
   - "6"
-  - "4"
-  - "0.12"
-  - "0.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3053 @@
+{
+  "name": "base64url",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "clean-yaml-object": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+      "dev": true
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "coveralls": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "2.7.3"
+          }
+        }
+      }
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.3",
+        "which": "1.3.0"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deeper": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
+      "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.15.1",
+        "is-my-json-valid": "2.17.2",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nyc": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-6.6.1.tgz",
+      "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
+      "dev": true,
+      "requires": {
+        "append-transform": "0.4.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.2.0",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.1",
+        "glob": "7.0.3",
+        "istanbul": "0.4.3",
+        "md5-hex": "1.3.0",
+        "micromatch": "2.3.8",
+        "mkdirp": "0.5.1",
+        "pkg-up": "1.0.0",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.5.2",
+        "signal-exit": "3.0.0",
+        "source-map": "0.5.6",
+        "spawn-wrap": "1.2.3",
+        "test-exclude": "1.1.0",
+        "yargs": "4.7.1"
+      },
+      "dependencies": {
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.1.4"
+          },
+          "dependencies": {
+            "write-file-atomic": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.4",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              },
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.4",
+                  "bundled": true,
+                  "dev": true
+                },
+                "imurmurhash": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true
+                },
+                "slide": {
+                  "version": "1.1.6",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          },
+          "dependencies": {
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              },
+              "dependencies": {
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          },
+          "dependencies": {
+            "commondir": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              },
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.4",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn-async": "2.2.4",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
+          },
+          "dependencies": {
+            "cross-spawn-async": {
+              "version": "2.2.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.0.1",
+                "which": "1.2.10"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.0.0"
+                  },
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "yallist": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "signal-exit": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "which": {
+              "version": "1.2.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isexe": "1.1.2"
+              },
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
+          },
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "1.3.3",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.4"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.1",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "istanbul": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.7",
+            "async": "1.5.2",
+            "escodegen": "1.8.0",
+            "esprima": "2.7.2",
+            "fileset": "0.2.1",
+            "handlebars": "4.0.5",
+            "js-yaml": "3.6.1",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.3.3",
+            "resolve": "1.1.7",
+            "supports-color": "3.1.2",
+            "which": "1.2.10",
+            "wordwrap": "1.0.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "bundled": true,
+              "dev": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "bundled": true,
+              "dev": true
+            },
+            "escodegen": {
+              "version": "1.8.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "esprima": "2.7.2",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.1",
+                "source-map": "0.2.0"
+              },
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "optionator": {
+                  "version": "0.8.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "deep-is": "0.1.3",
+                    "fast-levenshtein": "1.1.3",
+                    "levn": "0.3.0",
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2",
+                    "wordwrap": "1.0.0"
+                  },
+                  "dependencies": {
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.1.3",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "levn": {
+                      "version": "0.3.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
+                      }
+                    },
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "type-check": {
+                      "version": "0.3.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "prelude-ls": "1.1.2"
+                      }
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.2",
+              "bundled": true,
+              "dev": true
+            },
+            "fileset": {
+              "version": "0.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "5.0.15",
+                "minimatch": "2.0.10"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
+                  },
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.4"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.1",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.1",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "4.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.6.2"
+              },
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.6.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "async": "0.2.10",
+                    "source-map": "0.5.6",
+                    "uglify-to-browserify": "1.0.2",
+                    "yargs": "3.10.0"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "source-map": {
+                      "version": "0.5.6",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "yargs": {
+                      "version": "3.10.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "center-align": "0.1.3",
+                            "right-align": "0.1.3",
+                            "wordwrap": "0.0.2"
+                          },
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.3",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "align-text": "0.1.4",
+                                "lazy-cache": "1.0.4"
+                              },
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
+                                  },
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.3",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "is-buffer": "1.1.3"
+                                      },
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.3",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.4",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "1.0.4",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "align-text": "0.1.4"
+                              },
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "bundled": true,
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
+                                  },
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.3",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "is-buffer": "1.1.3"
+                                      },
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.3",
+                                          "bundled": true,
+                                          "dev": true,
+                                          "optional": true
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.4",
+                                      "bundled": true,
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "bundled": true,
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.2.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        },
+                        "window-size": {
+                          "version": "0.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.6.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "argparse": "1.0.7",
+                "esprima": "2.7.2"
+              },
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  },
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "abbrev": "1.0.7"
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.7",
+              "bundled": true,
+              "dev": true
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isexe": "1.1.2"
+              },
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          },
+          "dependencies": {
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.0.3",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.0",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-flatten": "1.0.1"
+              },
+              "dependencies": {
+                "arr-flatten": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              },
+              "dependencies": {
+                "expand-range": {
+                  "version": "1.8.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "fill-range": "2.2.3"
+                  },
+                  "dependencies": {
+                    "fill-range": {
+                      "version": "2.2.3",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.5",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.5.4"
+                      },
+                      "dependencies": {
+                        "is-number": {
+                          "version": "2.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "kind-of": "3.0.3"
+                          }
+                        },
+                        "isobject": {
+                          "version": "2.1.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "isarray": "1.0.0"
+                          },
+                          "dependencies": {
+                            "isarray": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "randomatic": {
+                          "version": "1.1.5",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "is-number": "2.1.0",
+                            "kind-of": "3.0.3"
+                          }
+                        },
+                        "repeat-string": {
+                          "version": "1.5.4",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "preserve": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "repeat-element": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              },
+              "dependencies": {
+                "is-posix-bracket": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "filename-regex": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.3"
+              },
+              "dependencies": {
+                "is-buffer": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "normalize-path": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "object.omit": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "for-own": "0.1.4",
+                "is-extendable": "0.1.1"
+              },
+              "dependencies": {
+                "for-own": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "for-in": "0.1.5"
+                  },
+                  "dependencies": {
+                    "for-in": {
+                      "version": "0.1.5",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "is-extendable": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "parse-glob": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.2",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              },
+              "dependencies": {
+                "glob-base": {
+                  "version": "0.3.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob-parent": "2.0.0",
+                    "is-glob": "2.0.1"
+                  },
+                  "dependencies": {
+                    "glob-parent": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-glob": "2.0.1"
+                      }
+                    }
+                  }
+                },
+                "is-dotfile": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "regex-cache": {
+              "version": "0.4.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+              },
+              "dependencies": {
+                "is-equal-shallow": {
+                  "version": "0.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-primitive": "2.0.0"
+                  }
+                },
+                "is-primitive": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "pkg-up": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.0.3"
+          }
+        },
+        "signal-exit": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.1",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.1",
+            "rimraf": "2.5.2",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "signal-exit": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "which": {
+              "version": "1.2.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isexe": "1.1.2"
+              },
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "test-exclude": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "lodash.assign": "4.0.9",
+            "micromatch": "2.3.8",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "4.0.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
+              },
+              "dependencies": {
+                "lodash.keys": {
+                  "version": "4.0.7",
+                  "bundled": true,
+                  "dev": true
+                },
+                "lodash.rest": {
+                  "version": "4.0.3",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
+                  },
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.4",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "error-ex": "1.3.0"
+                          },
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.3.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
+                              "dependencies": {
+                                "is-arrayish": {
+                                  "version": "0.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "is-utf8": "0.2.1"
+                          },
+                          "dependencies": {
+                            "is-utf8": {
+                              "version": "0.2.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.5",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.1"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
+                              },
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.4",
+                                  "bundled": true,
+                                  "dev": true
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "path-type": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.4",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yargs": {
+          "version": "4.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.0.9",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.1",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.1",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.0.0"
+              },
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "wrap-ansi": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "string-width": "1.0.1"
+                  }
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.assign": {
+              "version": "4.0.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
+              },
+              "dependencies": {
+                "lodash.keys": {
+                  "version": "4.0.7",
+                  "bundled": true,
+                  "dev": true
+                },
+                "lodash.rest": {
+                  "version": "4.0.3",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lcid": "1.0.0"
+              },
+              "dependencies": {
+                "lcid": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "invert-kv": "1.0.0"
+                  },
+                  "dependencies": {
+                    "invert-kv": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "pkg-conf": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.0",
+                "symbol": "0.2.3"
+              },
+              "dependencies": {
+                "load-json-file": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.4",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "strip-bom": "2.0.0"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.4",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "parse-json": {
+                      "version": "2.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "error-ex": "1.3.0"
+                      },
+                      "dependencies": {
+                        "error-ex": {
+                          "version": "1.3.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "is-arrayish": "0.2.1"
+                          },
+                          "dependencies": {
+                            "is-arrayish": {
+                              "version": "0.2.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-bom": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-utf8": "0.2.1"
+                      },
+                      "dependencies": {
+                        "is-utf8": {
+                          "version": "0.2.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "symbol": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
+                  },
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.4",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "error-ex": "1.3.0"
+                          },
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.3.0",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
+                              "dependencies": {
+                                "is-arrayish": {
+                                  "version": "0.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "is-utf8": "0.2.1"
+                          },
+                          "dependencies": {
+                            "is-utf8": {
+                              "version": "0.2.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.5",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.1"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.2",
+                              "bundled": true,
+                              "dev": true,
+                              "requires": {
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
+                              },
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.4",
+                                  "bundled": true,
+                                  "dev": true
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.2.1",
+                                  "bundled": true,
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "path-type": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.4",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "set-blocking": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "window-size": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "yargs-parser": {
+              "version": "2.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "2.1.1",
+                "lodash.assign": "4.0.9"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "only-shallow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
+      "integrity": "sha1-cc7O26kyS8BRiu8Q7AgNMkncJGU=",
+      "dev": true
+    },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.7.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.2.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+      "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "stack-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-0.4.0.tgz",
+      "integrity": "sha1-lAy4L8z6hOj/Lz/fKT/ngBa+zNE=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+      "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
+      "dev": true
+    },
+    "tap": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-6.1.1.tgz",
+      "integrity": "sha1-bWHVgqOjp7pUCbbNaLZrwqTFIxM=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "clean-yaml-object": "0.1.0",
+        "coveralls": "2.13.3",
+        "deeper": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "isexe": "1.1.2",
+        "js-yaml": "3.11.0",
+        "nyc": "6.6.1",
+        "only-shallow": "1.2.0",
+        "opener": "1.4.3",
+        "os-homedir": "1.0.1",
+        "readable-stream": "2.3.6",
+        "signal-exit": "2.1.2",
+        "stack-utils": "0.4.0",
+        "supports-color": "1.3.1",
+        "tap-mocha-reporter": "0.0.27",
+        "tap-parser": "1.3.2",
+        "tmatch": "2.0.1"
+      }
+    },
+    "tap-mocha-reporter": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-0.0.27.tgz",
+      "integrity": "sha1-svcvPh6Lp4DuApGPzes6QNqAGPc=",
+      "dev": true,
+      "requires": {
+        "color-support": "1.1.3",
+        "debug": "2.6.9",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "js-yaml": "3.11.0",
+        "readable-stream": "1.1.14",
+        "tap-parser": "1.3.2",
+        "unicode-length": "1.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true,
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "tap-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.3.2.tgz",
+      "integrity": "sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=",
+      "dev": true,
+      "requires": {
+        "events-to-array": "1.1.2",
+        "inherits": "2.0.3",
+        "js-yaml": "3.11.0",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "tmatch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
+      "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "unicode-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
+      "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/src/base64url.ts
+++ b/src/base64url.ts
@@ -6,11 +6,11 @@ function encode(input: string | Buffer, encoding: string = "utf8"): string {
     if (Buffer.isBuffer(input)) {
         return fromBase64(input.toString("base64"));
     }
-    return fromBase64(new Buffer(input as string, encoding).toString("base64"));
+    return fromBase64(Buffer.from(input as string, encoding).toString("base64"));
 };
 
 function decode(base64url: string, encoding: string = "utf8"): string {
-    return new Buffer(toBase64(base64url), "base64").toString(encoding);
+    return Buffer.from(toBase64(base64url), "base64").toString(encoding);
 }
 
 function toBase64(base64url: string | Buffer): string {
@@ -30,7 +30,7 @@ function fromBase64(base64: string): string {
 }
 
 function toBuffer(base64url: string): Buffer {
-    return new Buffer(toBase64(base64url), "base64");
+    return Buffer.from(toBase64(base64url), "base64");
 }
 
 export interface Base64Url {

--- a/src/pad-string.ts
+++ b/src/pad-string.ts
@@ -10,7 +10,7 @@ export default function padString(input: string): string {
     let position = stringLength;
     let padLength = segmentLength - diff;
     let paddedStringLength = stringLength + padLength;
-    let buffer = new Buffer(paddedStringLength);
+    let buffer = Buffer.alloc(paddedStringLength);
 
     buffer.write(input);
 

--- a/test/base64url.test.js
+++ b/test/base64url.test.js
@@ -4,7 +4,7 @@ const base64url = require('..');
 const testBuffer = fs.readFileSync(__dirname + '/test.jpg');
 
 function base64(s) {
-  return Buffer(s, 'binary').toString('base64');
+  return Buffer.from(s, 'binary').toString('base64');
 }
 
 test('from string to base64url', function (t) {
@@ -43,7 +43,7 @@ test('from base64url to string', function (t) {
 
 test('from base64url to string (buffer)', function (t) {
   const b64url = base64url(testBuffer, 'binary');
-  const result = base64url.decode(new Buffer(b64url), 'binary');
+  const result = base64url.decode(Buffer.from(b64url), 'binary');
   t.same(result, testBuffer.toString('binary'), 'should be able to decode');
   t.end();
 });


### PR DESCRIPTION
refs: https://hackerone.com/reports/321687
refs: https://snyk.io/vuln/npm:base64url:20180511

remove all instances of the buffer constructor and use Buffer.from or Buffer.alloc as neccessary

Much secure