### PR TITLE
Add typings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "For encoding to/from base64urls",
   "main": "index.js",
+  "typings": "./dist/base64url.d.ts",
   "files": [
     "dist/",
     "index.js"


### PR DESCRIPTION
Added `typings` in package.json to declare the location of type file.
ref. https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html
This issue resolves https://github.com/brianloveswords/base64url/issues/29 .

Tested in TypesScript 2.8.3
This would be helpful for many of typescript users.

Regards,