### PR TITLE
Fix encode example in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,8 @@ base64url encode `input`. Input should be a `string` or a `Buffer`.
 Example
 
 ```js
-> base64url("ladies and gentlemen we are floating in space")
-'bGFkaWVzIGFuZCBnZW50bGVtYW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ'
+> base64url("ladies and gentlemen, we are floating in space")
+'bGFkaWVzIGFuZCBnZW50bGVtZW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ'
 ```
 
 ---


### PR DESCRIPTION
Decoding `bGFkaWVzIGFuZCBnZW50bGVtYW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ` gives "ladies and gentleman, we are floating in space"

Note `a` in gentlem**a**n. It should be gentlem**e**n 😄 

See https://en.wikipedia.org/wiki/Ladies_and_Gentlemen_We_Are_Floating_in_Space